### PR TITLE
Add a charset meta tag to the template.

### DIFF
--- a/view.ejs
+++ b/view.ejs
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="utf-8">
     <% css.forEach(function (href) { %>
       <link href="<%= href %>" rel="stylesheet">
     <% }) %>


### PR DESCRIPTION
This allows you to use UTF-8 in your source files and have the browser actually display it, instead of gibberishing.
