### PR TITLE
HOTFIX: use mutiple versions of greadme by configable port number.

### DIFF
--- a/bin/greadme
+++ b/bin/greadme
@@ -14,7 +14,9 @@ process.title = 'greadme';
 // TODO configurable
 var fileArg = process.argv[2];
 var host = 'localhost'
-var port = 8124
+// HOTFIX: use mutiple versions of greadme by configable port number. Use -p [port number].
+// This fix is of quick fix quality.
+var port = process.argv.indexOf("-p") > 0 && process.argv[process.argv.indexOf("-p") + 1] || 8124
 
 function readme(dir) {
   var exts = 'markdown md'.split(' ')


### PR DESCRIPTION
Use `greadme readme.md -p [port number]`. See issue aheckmann/greadme#8
This fix is of quick fix quality.
