### PR TITLE
Update marked dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "preview"
   ],
   "dependencies": {
-    "marked": "0.2.9",
-    "request": "2.12.0",
+    "marked": "0.3.2",
+    "request": "2.40.0",
     "express": "3.3.3",
     "ejs": "0.8.4",
     "open": "0.0.3"


### PR DESCRIPTION
See https://nodesecurity.io/advisories/marked_multiple_content_injection_vulnerabilities

(there was also a request+qs vuln that was fixed in 2.40.0, and i think recent changes in Express, which you may want to bump to 3.16.0 (or whatever is latest), which included a fix to connect+qs vuln.
