### PR TITLE
Handle anchor links

### DIFF
--- a/view.ejs
+++ b/view.ejs
@@ -8,6 +8,19 @@
     <style type="text/css">
        #readme, #file-explorer { width: 920px;margin: 0 auto; }
     </style>
+    <script>
+    window.addEventListener('hashchange', () => {
+      if (document.querySelector(':target')) {
+        return;
+      }
+
+      const hash = location.hash.substring(1).toLowerCase();
+      const element = document.querySelector(`#user-content-${hash}`);
+      if (element) {
+        element.scrollIntoView();
+      }
+    });
+    </script>
   </head>
   <body>
     <% if (dir) { %>


### PR DESCRIPTION
These days, GitHub's markdown output generates IDs prefixed with "user-content-", then uses JavaScript to intercept normal navigations to them and scroll. We do the same.

Closes #13.